### PR TITLE
Aarch64 fixes

### DIFF
--- a/uefi-bootloader/src/arch/aarch64/memory.rs
+++ b/uefi-bootloader/src/arch/aarch64/memory.rs
@@ -300,7 +300,8 @@ impl PageTableEntry {
         PhysicalAddress::new_canonical(self.0 as usize & (!(PAGE_SIZE - 1) & !(0xffff << 48)))
     }
 
-    fn set(&mut self, frame: Frame, flags: PteFlags) {
+    // FIXME
+    fn set(&mut self, frame: Frame, _flags: PteFlags) {
         // self.0 = frame.start_address().value() as u64 | flags.0;
         self.0 = frame.start_address().value() as u64 | 0x70f;
     }

--- a/uefi-bootloader/src/arch/aarch64/memory.rs
+++ b/uefi-bootloader/src/arch/aarch64/memory.rs
@@ -55,7 +55,7 @@ impl PteFlags {
     }
 
     pub(crate) fn present(self, enable: bool) -> Self {
-        const BITS: u64 = 1;
+        const BITS: u64 = 1 << 0;
 
         if enable {
             Self(self.0 | BITS)

--- a/uefi-bootloader/src/arch/aarch64/mod.rs
+++ b/uefi-bootloader/src/arch/aarch64/mod.rs
@@ -24,7 +24,7 @@ pub(crate) unsafe fn jump_to_kernel(
     barrier::isb(barrier::SY);
 
     // install the new page table
-    let page_table_addr = page_table as u64;
+    let page_table_addr = page_table_frame as u64;
     TTBR0_EL1.write(
           TTBR0_EL1::ASID.val(ASID_ZERO as u64)
         + TTBR0_EL1::BADDR.val(page_table_addr >> 1)

--- a/uefi-bootloader/src/arch/aarch64/mod.rs
+++ b/uefi-bootloader/src/arch/aarch64/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod memory;
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) unsafe fn jump_to_kernel(
-    page_table: *const (),
+    page_table_frame: *const (),
     entry_point: *const (),
     boot_info: *const (),
     stack_top: *const (),

--- a/uefi-bootloader/src/arch/aarch64/mod.rs
+++ b/uefi-bootloader/src/arch/aarch64/mod.rs
@@ -1,11 +1,11 @@
-// FIXME: This doesn't work.
-
+use crate::memory::{Frame, VirtualAddress};
 use core::arch::asm;
 use cortex_a::{
     asm::barrier,
     registers::{MAIR_EL1, SCTLR_EL1, TCR_EL1, TTBR0_EL1},
 };
 use tock_registers::interfaces::{ReadWriteable, Writeable};
+use uefi_bootloader_api::BootInformation;
 
 pub(crate) mod memory;
 
@@ -13,17 +13,17 @@ pub(crate) mod memory;
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) unsafe fn jump_to_kernel(
-    page_table_frame: *const (),
-    entry_point: *const (),
-    boot_info: *const (),
-    stack_top: *const (),
+    page_table_frame: Frame,
+    entry_point: VirtualAddress,
+    boot_info: &'static BootInformation,
+    stack_top: VirtualAddress,
 ) -> ! {
     // disable the MMU
     SCTLR_EL1.modify(SCTLR_EL1::M::Disable);
     barrier::isb(barrier::SY);
 
     // install the new page table
-    let page_table_addr = page_table_frame as u64;
+    let page_table_addr = page_table_frame.start_address().value() as u64;
     TTBR0_EL1
         .write(TTBR0_EL1::ASID.val(ASID_ZERO.into()) + TTBR0_EL1::BADDR.val(page_table_addr >> 1));
 
@@ -43,9 +43,9 @@ pub(crate) unsafe fn jump_to_kernel(
             "mov sp, {}",
             // jump to the entry point
             "br {}",
-            in(reg) 0,
-            in(reg) stack_top,
-            in(reg) entry_point,
+            in(reg) 0usize,
+            in(reg) stack_top.value(),
+            in(reg) entry_point.value(),
             in("x0") boot_info,
             options(noreturn)
         )

--- a/uefi-bootloader/src/arch/aarch64/mod.rs
+++ b/uefi-bootloader/src/arch/aarch64/mod.rs
@@ -4,38 +4,52 @@ use crate::KernelContext;
 use core::arch::asm;
 use cortex_a::{
     asm::barrier,
-    registers::{MAIR_EL1, SCTLR_EL1, TCR_EL1},
+    registers::{MAIR_EL1, SCTLR_EL1, TCR_EL1, TTBR0_EL1},
 };
 use tock_registers::interfaces::{ReadWriteable, Writeable};
 
 pub(crate) mod memory;
 
-pub(crate) fn pre_context_switch_actions() {
-    enable_mmu();
-    configure_translation_registers();
-}
-
 // The function needs to take ownership of the context so that it remains valid
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]
-pub(crate) unsafe fn jump_to_kernel(context: KernelContext) -> ! {
-    // SAFETY: The caller guarantees that the context switch function is
-    // identity-mapped, the stack pointer is mapped in the new page table, and the
-    // kernel entry point is correct.
-    unsafe {
-        // TODO: Set stack pointer, and jump to entry point.
-        core::arch::asm!(
-            "msr ttbr0_el1, {}",
-            "tlbi alle1",
-            "dsb ish",
-            "isb",
-            "2:",
-            "mov x2, 0xdead",
-            "b 2b",
-            in(reg) (context.page_table_frame.start_address().value() as u64),
-            options(noreturn),
-        )
-    };
+pub(crate) unsafe fn jump_to_kernel(
+    page_table: *const (),
+    entry_point: *const (),
+    boot_info: *const (),
+    stack_top: *const (),
+) -> ! {
+    // disable the MMU
+    SCTLR_EL1.modify(SCTLR_EL1::M::Disable);
+    barrier::isb(barrier::SY);
+
+    // install the new page table
+    let page_table_addr = page_table as u64;
+    TTBR0_EL1.write(
+          TTBR0_EL1::ASID.val(ASID_ZERO as u64)
+        + TTBR0_EL1::BADDR.val(page_table_addr >> 1)
+    );
+
+    configure_translation_registers();
+
+    // re-enable the MMU
+    barrier::isb(barrier::SY);
+    SCTLR_EL1.modify(SCTLR_EL1::M::Enable);
+    barrier::isb(barrier::SY);
+
+    // flush the tlb
+    asm!("tlbi aside1, {}", in(reg) 0usize);
+
+    // flush the tlb
+    asm!("mov sp, {}", in(reg) stack_top);
+
+    // jump to the entry point defined by the kernel
+    asm!(
+        "br {}",
+        in(reg) entry_point,
+        in("x0") boot_info,
+        options(noreturn)
+    )
 }
 
 pub(crate) fn halt() -> ! {
@@ -45,13 +59,9 @@ pub(crate) fn halt() -> ! {
     }
 }
 
-const THESEUS_ASID: u16 = 0;
+const ASID_ZERO: u16 = 0;
 
-fn enable_mmu() {
-    SCTLR_EL1.modify(SCTLR_EL1::M::Enable);
-    barrier::isb(barrier::SY);
-}
-
+#[inline(always)]
 fn configure_translation_registers() {
     MAIR_EL1.write(
         MAIR_EL1::Attr1_Device::nonGathering_nonReordering_EarlyWriteAck
@@ -70,6 +80,4 @@ fn configure_translation_registers() {
             + TCR_EL1::HA::Enable
             + TCR_EL1::HD::Enable,
     );
-
-    barrier::isb(barrier::SY);
 }

--- a/uefi-bootloader/src/arch/unsupported/mod.rs
+++ b/uefi-bootloader/src/arch/unsupported/mod.rs
@@ -1,15 +1,17 @@
-use crate::KernelContext;
+use crate::memory::{Frame, VirtualAddress};
+use uefi_bootloader_api::BootInformation;
 
 pub(crate) mod memory;
-
-pub(crate) fn pre_context_switch_actions() {
-    unimplemented!();
-}
 
 // The function needs to take ownership of the context so that it remains valid
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]
-pub(crate) unsafe fn jump_to_kernel(_context: KernelContext) -> ! {
+pub(crate) unsafe fn jump_to_kernel(
+    _page_table_frame: Frame,
+    _entry_point: VirtualAddress,
+    _boot_info: &'static BootInformation,
+    _stack_top: VirtualAddress,
+) -> ! {
     unimplemented!();
 }
 

--- a/uefi-bootloader/src/arch/x86_64/mod.rs
+++ b/uefi-bootloader/src/arch/x86_64/mod.rs
@@ -6,17 +6,22 @@ pub(crate) mod memory;
 // The function needs to take ownership of the context so that it remains valid
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]
-pub(crate) unsafe fn jump_to_kernel(context: KernelContext) -> ! {
+pub(crate) unsafe fn jump_to_kernel(
+    page_table_frame: *const (),
+    entry_point: *const (),
+    boot_info: *const (),
+    stack_top: *const (),
+) -> ! {
     // SAFETY: The caller guarantees that the context switch function is
     // identity-mapped, the stack pointer is mapped in the new page table, and the
     // kernel entry point is correct.
     unsafe {
         asm!(
             "mov cr3, {}; mov rsp, {}; jmp {}",
-            in(reg) context.page_table_frame.start_address().value(),
-            in(reg) context.stack_top.value(),
-            in(reg) context.entry_point.value(),
-            in("rdi") context.boot_info,
+            in(reg) page_table_frame,
+            in(reg) stack_top,
+            in(reg) entry_point,
+            in("rdi") boot_info,
             options(noreturn),
         );
     }

--- a/uefi-bootloader/src/arch/x86_64/mod.rs
+++ b/uefi-bootloader/src/arch/x86_64/mod.rs
@@ -3,8 +3,6 @@ use core::arch::asm;
 
 pub(crate) mod memory;
 
-pub(crate) fn pre_context_switch_actions() {}
-
 // The function needs to take ownership of the context so that it remains valid
 // when we switch page tables.
 #[allow(clippy::needless_pass_by_value)]

--- a/uefi-bootloader/src/main.rs
+++ b/uefi-bootloader/src/main.rs
@@ -78,14 +78,9 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     );
 
     let boot_info = context.create_boot_info(frame_buffer, rsdp_address, modules, elf_sections);
-    info!("created boot info: {boot_info:#x?}");
+    info!("created boot info: {boot_info:x?}");
 
-    let entry_point = entry_point.value() as _;
-    let stack_top = stack_top.value() as _;
-    let boot_info = boot_info as *const _ as _;
-    let page_table_frame = page_table_frame.start_address().value() as _;
-
-    info!("about to jump to kernel: 0x{:x}", entry_point as usize);
+    info!("about to jump to kernel: {:x?}", entry_point.value());
     unsafe { jump_to_kernel(page_table_frame, entry_point, boot_info, stack_top) };
 }
 
@@ -140,15 +135,6 @@ fn get_rsdp_address(system_table: &SystemTable<Boot>) -> Option<usize> {
     // if no ACPI2 RSDP is found, look for a ACPI1 RSDP
     let rsdp = acpi2_rsdp.or_else(|| config_entries.find(|entry| matches!(entry.guid, ACPI_GUID)));
     rsdp.map(|entry| entry.address as usize)
-}
-
-/// The context necessary to switch to the kernel.
-#[derive(Clone, Copy, Debug)]
-struct KernelContext {
-    page_table_frame: Frame,
-    stack_top: VirtualAddress,
-    entry_point: VirtualAddress,
-    boot_info: &'static BootInformation,
 }
 
 #[panic_handler]

--- a/uefi-bootloader/src/main.rs
+++ b/uefi-bootloader/src/main.rs
@@ -18,7 +18,6 @@ mod modules;
 mod util;
 
 use crate::arch::jump_to_kernel;
-use crate::memory::{Frame, VirtualAddress};
 use core::{fmt::Write, ptr::NonNull};
 use log::{error, info};
 use uefi::{
@@ -30,7 +29,7 @@ use uefi::{
     },
     Handle, Status,
 };
-use uefi_bootloader_api::{BootInformation, FrameBuffer, FrameBufferInfo, PixelFormat};
+use uefi_bootloader_api::{FrameBuffer, FrameBufferInfo, PixelFormat};
 
 pub(crate) use context::{BootContext, RuntimeContext};
 
@@ -81,6 +80,7 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     info!("created boot info: {boot_info:x?}");
 
     info!("about to jump to kernel: {:x?}", entry_point.value());
+    // SAFETY: Everything is correctly mapped.
     unsafe { jump_to_kernel(page_table_frame, entry_point, boot_info, stack_top) };
 }
 


### PR DESCRIPTION
This includes two fixes:

- the elf section loading code assumed loading addresses to be page-aligned, which was wrong
- the `jump_to_kernel` function is now fully implemented on aarch64 too.